### PR TITLE
fixed option table layout in docs

### DIFF
--- a/docs/sphinx/source/_static/custom.css
+++ b/docs/sphinx/source/_static/custom.css
@@ -47,3 +47,12 @@ code.xref {
     color: black!important;
     font-weight: bold;
 }
+
+/* Fix table rows in option tables */
+.option-list td{
+    border:none!important;
+}
+
+.option-list td.option-group, .option-list td.option-group + td{
+    border-top: 1px solid #888 !important;
+}

--- a/uberdot/constants.py
+++ b/uberdot/constants.py
@@ -33,7 +33,7 @@ from uberdot.utils import find_files
 from uberdot.utils import get_user_env_var
 from uberdot.utils import normpath
 
-VERSION = "1.12.14_3"
+VERSION = "1.12.15_3"
 """Version numbers, seperated by underscore.
 
 First part is the version of uberdot. The second part (after the underscore)


### PR DESCRIPTION
The option table (list of all options of the command line interface) in the html doc was pretty ugly and quite confusing.
This PR fixes this by overwriting the cell borders of the alabaster theme.